### PR TITLE
Allow linter to run under source.ruby.rails, with -R flag.

### DIFF
--- a/lib/linter-rubocop.coffee
+++ b/lib/linter-rubocop.coffee
@@ -24,6 +24,9 @@ class LinterRubocop extends Linter
   constructor: (editor)->
     super(editor)
 
+    if editor.getGrammar().scopeName == 'source.ruby.rails'
+      @cmd += " -R"
+
     config = findFile(@cwd, '.rubocop.yml')
     if config
       @cmd += " --config #{config}"


### PR DESCRIPTION
This pull request should fix #5.
