### PR TITLE
Edited README.md: Added note to Settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,12 @@ $ apm install linter-rubocop
 You can configure linter-rubocop by editing ~/.atom/config.cson (choose Open Your Config in Atom menu):
 ```
 'linter-rubocop':
-  'rubocopExecutablePath': null #rubocop path. run 'which rubocop' to find the path
+  'rubocopExecutablePath': null   #rubocop path (see notes)
 ```
-**Note**: This plugin finds the nearest .rubocop.yml file and uses the --config command line argument to use that file, so you may not use the --config argument in the linter settings.
+**Notes**:
+
+1. Run 'which rubocop' on commandline to find the path for `rubocopExecutablePath`, and use the reported path minus 'bin/rubocop'. So for example, if 'which rubocop' reports `/Users/username/.rvm/gems/ruby-2.1.2/bin/rubocop`  then use `/Users/username/.rvm/gems/ruby-2.1.2/`.
+1. This plugin finds the nearest .rubocop.yml file and uses the --config command line argument to use that file, so you may not use the --config argument in the linter settings.
 
 ## Contributing
 If you would like to contribute enhancements or fixes, please do the following:


### PR DESCRIPTION
Extended note in Settings:
- moved instruction to run 'which rubocop' from config.cson snippet to notes (added 'see notes' to snippet).
- expanded on instruction by specifying to remove 'bin/rubocop' from path.
- this change relates to a confusion for users that was resolved in the discussion for issue #7
