### PR TITLE
Modify command line arguments, add force-exclusion

### DIFF
--- a/lib/linter-rubocop.coffee
+++ b/lib/linter-rubocop.coffee
@@ -9,7 +9,7 @@ class LinterRubocop extends Linter
 
   # A string, list, tuple or callable that returns a string, list or tuple,
   # containing the command line (with arguments) used to lint.
-  cmd: 'rubocop --format emacs'
+  cmd: 'rubocop --force-exclusion --format emacs'
 
   linterName: 'rubocop'
 
@@ -23,7 +23,7 @@ class LinterRubocop extends Linter
     super(editor)
 
     if editor.getGrammar().scopeName == 'source.ruby.rails'
-      @cmd += " -R"
+      @cmd += " --rails"
 
     config = findFile(@cwd, '.rubocop.yml')
     if config


### PR DESCRIPTION
I had excluded files in my `.rubocop.yml` rules (e.g. `db/schema.rb`), but was still seeing rubocop warnings in Atom.  Passing the `--force-exclusion` argument does the trick:

> Force excluding files specified in the configuration `Exclude` even if they are explicitly passed as arguments.