### PR TITLE
Custom launch command

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -5,6 +5,13 @@ module.exports =
       description: 'The path where rubocop is located'
       type: 'string'
       default: ''
+    cmd:
+      title: 'Rubocop Custom Command'
+      description: 'Use a custom command to launch Rubocop. Please, do not ' +
+                   'forget the options --force-exclusion --format emacs. And ' +
+                   'do not forget to restart Atom or reload the packages.'
+      type: 'string'
+      default: 'rubocop --force-exclusion --format emacs'
 
   activate: ->
     console.log 'activate linter-rubocop'

--- a/lib/linter-rubocop.coffee
+++ b/lib/linter-rubocop.coffee
@@ -9,8 +9,7 @@ class LinterRubocop extends Linter
 
   # A string, list, tuple or callable that returns a string, list or tuple,
   # containing the command line (with arguments) used to lint.
-  cmd: atom.config.get("linter-rubocop.cmd") ||
-         'rubocop --force-exclusion --format emacs'
+  cmd: atom.config.get 'linter-rubocop.cmd'
 
   linterName: 'rubocop'
 

--- a/lib/linter-rubocop.coffee
+++ b/lib/linter-rubocop.coffee
@@ -9,7 +9,8 @@ class LinterRubocop extends Linter
 
   # A string, list, tuple or callable that returns a string, list or tuple,
   # containing the command line (with arguments) used to lint.
-  cmd: 'rubocop --force-exclusion --format emacs'
+  cmd: atom.config.get("linter-rubocop.cmd") ||
+         'rubocop --force-exclusion --format emacs'
 
   linterName: 'rubocop'
 


### PR DESCRIPTION
Enable the possibility of customising the Rubocop launch command.

This was very useful for me to be able to run Rucocop like `rvm 1.9.3 do rubocop --force-exclusion --format emacs`.

Hope this would be useful for someone else.