### PR TITLE
Set working directory

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -1,6 +1,6 @@
 {BufferedProcess, CompositeDisposable} = require 'atom'
 {exists, unlink, writeFile} = require 'fs'
-{join, resolve} = require 'path'
+{join, resolve, dirname} = require 'path'
 {randomBytes} = require 'crypto'
 {tmpdir} = require 'os'
 
@@ -33,6 +33,8 @@ lint = (editor, command, args) ->
         args...
         tmpPath
       ]
+      options:
+        cwd: dirname(editor.getPath())
       stdout: appendToOut
       stderr: appendToOut
       exit: -> cleanup ->


### PR DESCRIPTION
There is a bug: 
I use rbenv, and I have rubocop-rspec installed only for one (not global) ruby version. When I'm trying to lint a file, I'm getting an error because rubocop can't load rubocop-rspec. 

This PR fixes the issue.