### PR TITLE
Fix cwd if file is located in unexisting dir

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -14,17 +14,19 @@ findFile = (dir, file, cb) ->
 
 lint = (editor, command, args) ->
   filePath = editor.getPath()
+  fileDir = dirname(filePath)
   tmpPath = join tmpdir(), randomBytes(32).toString 'hex'
   out = ''
   err = ''
 
   appendToOut = (data) -> out += data
   appendToErr = (data) -> err += data
-  getConfig = (cb) -> findFile filePath, '.rubocop.yml', cb
+  getConfig = (cb) -> findFile fileDir, '.rubocop.yml', cb
+  getCwd = (cb) -> findFile fileDir, '', cb
   writeTmp = (cb) -> writeFile tmpPath, editor.getText(), cb
   cleanup = (cb) -> unlink tmpPath, cb
 
-  new Promise (resolve, reject) -> getConfig (config) -> writeTmp (er) ->
+  new Promise (resolve, reject) -> getConfig (config) -> writeTmp (er) -> getCwd (cwd) ->
     return reject er if er
     new BufferedProcess
       command: command
@@ -36,7 +38,7 @@ lint = (editor, command, args) ->
         tmpPath
       ]
       options:
-        cwd: dirname(editor.getPath())
+        cwd: cwd
       stdout: appendToOut
       stderr: appendToErr
       exit: -> cleanup ->


### PR DESCRIPTION
There is an issue:
I use rbenv. When I create a new file in an unexisting folder (with https://atom.io/packages/advanced-new-file for example), linter detects that unexisting folder as cwd, and rbenv can't set correct version of ruby. As a result, linter can't find rubocop and throws an error.

This PR resolves the issue by searching closest existing dir.