### PR TITLE
Add 'source.ruby.chef' to grammarScopes

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -81,7 +81,7 @@ module.exports =
     @subscriptions.dispose()
 
   provideLinter: ->
-    grammarScopes: ['source.ruby', 'source.ruby.rails', 'source.ruby.rspec'],
+    grammarScopes: ['source.ruby', 'source.ruby.rails', 'source.ruby.rspec', 'source.ruby.chef'],
     scope: 'file'
     lintOnFly: true
     lint: (editor) => lint editor, @executablePath, @additionalArguments


### PR DESCRIPTION
Adds 'source.ruby.chef' to the list of grammarScopes to support the [language-chef](https://github.com/darron/language-chef/) plugin.