### PR TITLE
Understand 'Exclude' config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+### Bugs fixed
+
+* Understand 'Exclude' config (most likely used with the --force-exclusion Additional Argument) [#43](https://github.com/AtomLinter/linter-rubocop/issues/43)
+
 # 0.2.2
 
 ### Bugs fixed

--- a/index.coffee
+++ b/index.coffee
@@ -43,7 +43,16 @@ lint = (editor, command, args) ->
       stdout: appendToOut
       stderr: appendToErr
       exit: -> cleanup ->
-        try {offenses: errors} = JSON.parse(out).files[0]
+        jsonOutput = JSON.parse(out)
+
+        # Set errors to an empty array if jsonOutput.summary.offense_count is 0
+        # Set errors to jsonOutput.files[0].offenses otherwise
+        offense_count = try jsonOutput.summary.offense_count
+        errors = if offense_count == 0
+          []
+        else
+          try jsonOutput.files[0].offenses
+
         return reject new Error "STDOUT:#{out}\nSTDERR:#{err}" unless errors
         resolve errors.map (error) ->
           {line, column, length} =

--- a/index.coffee
+++ b/index.coffee
@@ -36,7 +36,7 @@ lint = (editor, command, args) ->
         'json'
         (if config then ['-c', config] else [])...
         args...
-        tmpPath
+        filePath
       ]
       options:
         cwd: cwd


### PR DESCRIPTION
I really needed this in my Rails projects to avoid hundreds of linter warnings because of the db/schema.rb files.

linter-rubocop now uses the real filePath that matches against the 'Exclude' params in the config file. Just add the '--force-exclusion' Additional Arguments in linter-rubocop settings and this should work.

What do you guys think ?

fixes #43 