### PR TITLE
Add linter name

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -38,6 +38,7 @@ lint = (editor) ->
       range: [[line - 1, column - 1], [line - 1, column + length - 1]]
 
 linter =
+  name: 'RuboCop'
   grammarScopes: [
     'source.ruby'
     'source.ruby.rails'


### PR DESCRIPTION
Specifies the linter name, allowing the `linter` package to display it if the user chooses to.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/atomlinter/linter-rubocop/81)
<!-- Reviewable:end -->
