### PR TITLE
Run rubocop in a parent directory that has a .rubocop.yml file.

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -21,7 +21,9 @@ lint = (editor) ->
   convertOldConfig()
   command = atom.config.get(COMMAND_CONFIG_KEY).split(/\s+/).filter((i) -> i)
     .concat(DEFAULT_ARGS, filePath = editor.getPath())
-  cwd = path.dirname helpers.findFile filePath, '.'
+  cwd = path.dirname helpers.findFile filePath, '.rubocop.yml'
+  unless cwd
+    cwd = path.dirname filePath
   stdin = editor.getText()
   stream = 'both'
   helpers.exec(command[0], command[1..], {cwd, stdin, stream}).then (result) ->


### PR DESCRIPTION
If you are in a project that has a .rubocop.yml config file in the root
of the project, you used to have to specify an absolute path to that yml
in atom's config. This would mean you would have to change the config
each time you switch projects.

This change will find the parent directory that has the .rubocop.yml and
run rubocop from there. This allows lint-rubocop to work with mostly any
project out of the box.