### PR TITLE
Remove nonfunctional styling from description

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "linter-rubocop",
   "main": "./lib/index.coffee",
   "version": "0.5.0",
-  "description": "Lint `Ruby` on the fly, using rubocop",
+  "description": "Lint Ruby on the fly, using rubocop",
   "repository": "https://github.com/AtomLinter/linter-rubocop",
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
Not totally sure if this is best practice, but since the styling doesn't apply in the Atom interface I thought this would be better removed.

![screen shot 2016-11-01 at 8 22 20 pm](https://cloud.githubusercontent.com/assets/5923662/19912448/ea4461c6-a070-11e6-8417-0870f9ea5afb.png)
