### PR TITLE
Improve Atom startup time

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "engines": {
     "atom": ">=1.0.0 <2.0.0"
   },
+  "activationHooks": ["language-ruby:grammar-used"],
   "scripts": {
     "lint": "coffeelint lib && eslint spec",
     "test": "apm test"

--- a/spec/linter-rubocop-spec.js
+++ b/spec/linter-rubocop-spec.js
@@ -14,19 +14,15 @@ describe('The RuboCop provider for Linter', () => {
   beforeEach(() => {
     atom.workspace.destroyActivePaneItem();
 
-    // This whole beforeEach function is inspired by:
-    // https://github.com/AtomLinter/linter-jscs/pull/295/files
-    //
-    // See also:
-    // https://discuss.atom.io/t/activationhooks-break-unit-tests/36028/8
+    // Info about this beforeEach() implementation:
+    // https://github.com/AtomLinter/Meta/issues/15
     const activationPromise =
       atom.packages.activatePackage('linter-rubocop');
 
     waitsForPromise(() =>
-      atom.packages.activatePackage('language-ruby'));
-
-    waitsForPromise(() =>
-      atom.workspace.open(goodPath));
+      atom.packages.activatePackage('language-ruby').then(() =>
+        atom.workspace.open(goodPath)
+    ));
 
     atom.packages.triggerDeferredActivationHooks();
     waitsForPromise(() => activationPromise);

--- a/spec/linter-rubocop-spec.js
+++ b/spec/linter-rubocop-spec.js
@@ -13,12 +13,23 @@ const invalidWithoutUrlPath = path.join(__dirname, 'fixtures', 'invalid_without_
 describe('The RuboCop provider for Linter', () => {
   beforeEach(() => {
     atom.workspace.destroyActivePaneItem();
-    waitsForPromise(() => {
+
+    // This whole beforeEach function is inspired by:
+    // https://github.com/AtomLinter/linter-jscs/pull/295/files
+    //
+    // See also:
+    // https://discuss.atom.io/t/activationhooks-break-unit-tests/36028/8
+    const activationPromise =
       atom.packages.activatePackage('linter-rubocop');
-      return atom.packages.activatePackage('language-ruby').then(() =>
-        atom.workspace.open(goodPath)
-      );
-    });
+
+    waitsForPromise(() =>
+      atom.packages.activatePackage('language-ruby'));
+
+    waitsForPromise(() =>
+      atom.workspace.open(goodPath));
+
+    atom.packages.triggerDeferredActivationHooks();
+    waitsForPromise(() => activationPromise);
   });
 
   it('should be in the packages list', () =>


### PR DESCRIPTION
Before this change, activation was done on Atom startup, whether or not
you actually had any Ruby files open.

With this change in place, we postpone activation until the Atom
Ruby grammar's first use.

This improves startup time of my Atom by about 24ms, thus fixing one of
the top startup time offenders according to TimeCop.

For some frame of reference, I have 87 packages installed, and Timecop
lists all packages with startup times above 5ms.