### PR TITLE
Add Ruby-On-Rails and Chef Grammars to Activation

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "atom": ">=1.0.0 <2.0.0"
   },
   "activationHooks": [
-    "language-ruby:grammar-used"
+    "language-ruby:grammar-used",
+    "language-ruby-on-rails:grammar-used",
+    "language-chec:grammar-used"
   ],
   "scripts": {
     "lint": "coffeelint lib && eslint .",


### PR DESCRIPTION
Add `language-ruby-on-rails` and `language-chef` to the list of language packages that will trigger activation of this package when they are used.

Fixes #179.