### PR TITLE
Fix specs for rubocop@0.46.0

### DIFF
--- a/spec/fixtures/invalid_without_url.rb
+++ b/spec/fixtures/invalid_without_url.rb
@@ -1,7 +1,6 @@
 # There's an extra empty line before the closing of the class, that should irk
 # the Rubocop default config.
 class EmptyLinesAroundClassBody
-  def noop
-  end
+  def noop; end
 
 end

--- a/spec/linter-rubocop-spec.js
+++ b/spec/linter-rubocop-spec.js
@@ -106,7 +106,7 @@ describe('The RuboCop provider for Linter', () => {
           expect(messages[0].html).toBe(msgText);
           expect(messages[0].text).not.toBeDefined();
           expect(messages[0].filePath).toEqual(invalidWithoutUrlPath);
-          expect(messages[0].range).toEqual([[5, 0], [5, 1]]);
+          expect(messages[0].range).toEqual([[4, 0], [4, 1]]);
         }),
       );
     });


### PR DESCRIPTION
RuboCop v0.46.0 added a new rule `Style/EmptyMethod` which was causing one of the specs to fail, this corrects that issue.