### PR TITLE
Fix typo for language-chef under activationHooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "activationHooks": [
     "language-ruby:grammar-used",
     "language-ruby-on-rails:grammar-used",
-    "language-chec:grammar-used"
+    "language-chef:grammar-used"
   ],
   "scripts": {
     "lint": "coffeelint lib && eslint .",


### PR DESCRIPTION
Linter-rubocop v0.5.2 is not automatically linting chef code.  Language-chef was added to the activationHooks in 0.5.2, but looks like just a typo in that change ("chec" vs. "chef"). Tested this change locally and it restores the expected behavior.

Thanks for your work on this linter - it's very helpful!