### PR TITLE
Remove macOS testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,6 @@ matrix:
       rvm: 2.3.1
       env: ATOM_CHANNEL=beta
 
-    - os: osx
-      rvm: 2.2.2
-
 install:
   - gem install --no-document rubocop
 


### PR DESCRIPTION
Travis-CI has become completely unusable for macOS testing, with builds consistently taking over 2 hours to finish queueing.