### PR TITLE
Pass active editor from lint function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -196,8 +196,7 @@ export default {
         const { stdout, stderr } = await helpers.exec(command[0], command.slice(1), { cwd, stdin, stream: 'both' });
         const { files } = parseFromStd(stdout, stderr);
         const offenses = files && files[0] && files[0].offenses;
-        return (offenses || []).map(offense =>
-          forwardRubocopToLinter(offense, filePath, atom.workspace.getActiveTextEditor()));
+        return (offenses || []).map(offense => forwardRubocopToLinter(offense, filePath, editor));
       },
     };
   },


### PR DESCRIPTION
Addresses: https://github.com/AtomLinter/linter-rubocop/pull/200/files/2688f436d0db8072a8a7066230585e654ad690bf#diff-1fdf421c05c1140f6d71444ea2b27638