### PR TITLE
[BUGFIX] Documentation navigation regex

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -75,7 +75,7 @@ const getMarkDown = async (url) => {
     const beginSearch = byLine.slice(startingIndex + 1)
 
     // gobble all the documentation until you reach the next rule
-    const documentationForRule = takeWhile(beginSearch, x => !x.match(/\* <a name=/))
+    const documentationForRule = takeWhile(beginSearch, x => !x.match(/\* <a name=|##/))
     const markdownOutput = '***\n'.concat(documentationForRule.join('\n'))
 
     docsRuleCache.set(ruleName, markdownOutput)


### PR DESCRIPTION
Pending #207 
### Before
<img width="702" alt="screen shot 2017-04-07 at 12 40 19 pm" src="https://cloud.githubusercontent.com/assets/1264305/24816939/9c204646-1b8f-11e7-8d9a-290cd2c657c4.png">

### After
<img width="655" alt="screen shot 2017-04-07 at 12 40 47 pm" src="https://cloud.githubusercontent.com/assets/1264305/24816940/9c20f226-1b8f-11e7-80f0-d37691837365.png">

