### PR TITLE
Remove redundant linter-timeout

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,11 +19,6 @@
       "title": "Disable when no .rubocop.yml config file is found",
       "default": false,
       "description": "Only run linter if a RuboCop config file is found somewhere in the path for the current file."
-    },
-    "linterTimeout": {
-      "type": "number",
-      "default": 10000,
-      "description": "Override linter timeout (in ms). Helpful for Ruby runtimes with slow startup times (JRuby etc.)"
     }
   },
   "activationHooks": [

--- a/src/index.js
+++ b/src/index.js
@@ -160,11 +160,6 @@ export default {
         this.disableWhenNoConfigFile = value
       }),
     )
-    this.subscriptions.add(
-      atom.config.observe('linter-rubocop.linterTimeout', (value) => {
-        this.linterTimeout = value
-      }),
-    )
   },
 
   deactivate() {
@@ -202,7 +197,6 @@ export default {
           cwd,
           stdin,
           stream: 'both',
-          timeout: this.linterTimeout,
           uniqueKey: `linter-rubocop::${filePath}`,
         }
         const output = await helpers.exec(command[0], command.slice(1), exexOptions)

--- a/src/index.js
+++ b/src/index.js
@@ -197,9 +197,25 @@ export default {
           cwd,
           stdin,
           stream: 'both',
+          timeout: 10000,
           uniqueKey: `linter-rubocop::${filePath}`,
         }
-        const output = await helpers.exec(command[0], command.slice(1), exexOptions)
+
+        let output
+        try {
+          output = await helpers.exec(command[0], command.slice(1), exexOptions)
+        } catch (e) {
+          if (e.message !== 'Process execution timed out') throw e
+          atom.notifications.addInfo(
+            'Linter-Rubocop: Linter timed out',
+            {
+              description: 'Make sure you are not running Rubocop with a slow-starting interpreter like JRuby. ' +
+                           'If you are still seeing timeouts, consider running your linter `on save` and not `on change`, ' +
+                           'or reference https://github.com/AtomLinter/linter-rubocop/issues/202 .',
+            },
+          )
+          return null
+        }
         // Process was canceled by newer process
         if (output === null) { return null }
 


### PR DESCRIPTION
This was added as a quick fix for certain users. Unique process spawning/termination is the proper solution so getting rid of this feature as the base package has a sensible default anyway.

Essentially reverts #210 