### PR TITLE
Update Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,12 +34,16 @@ branches:
 git:
   depth: 10
 
+dist: trusty
+
 sudo: false
 
 addons:
   apt:
+    sources:
+    - ubuntu-toolchain-r-test
     packages:
-    - build-essential
-    - git
-    - libgnome-keyring-dev
+    - g++-6
     - fakeroot
+    - git
+    - libsecret-1-dev


### PR DESCRIPTION
Update the Travis CI congfiguration to the current state of `atom/ci`, fixing builds of both stable and beta Atom.