### PR TITLE
Asyncify the specs

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "eslint": "^4.6.0",
     "eslint-config-airbnb-base": "^12.0.0",
     "eslint-plugin-import": "^2.7.0",
+    "jasmine-fix": "^1.3.1",
     "tmp": "^0.0.33"
   },
   "package-deps": [

--- a/spec/.eslintrc.js
+++ b/spec/.eslintrc.js
@@ -1,6 +1,14 @@
 module.exports = {
   env: {
     atomtest: true,
-    jasmine: true
+    jasmine: true,
+  },
+  rules: {
+    "import/no-extraneous-dependencies": [
+      "error",
+      {
+        "devDependencies": true
+      }
+    ]
   }
 };


### PR DESCRIPTION
Bring in `jasmine-fix` to allow the use of `async`/`await` in the specs and refactor them to take advantage of this. Note that the handling of notifications was moved to the same implementation used in `linter-eslint`. It's a more generic implementation, and properly disposes of the subscription used to grab the notifications.