### PR TITLE
Adds the option to disable the Rubycop stdin flag (Closes #245)

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,12 @@
       "title": "Disable when no .rubocop.yml config file is found",
       "default": false,
       "description": "Only run linter if a RuboCop config file is found somewhere in the path for the current file."
+    },
+    "disableRubocopStdin": {
+      "type": "boolean",
+      "title": "Disable source code piping to Rubocop from the stdin",
+      "default": false,
+      "description": "This option removes the `--stdin` flag when calling Rubocop, which forces Rubocop to read the file itself. (Useful when using Rubocop in a Docker container)"
     }
   },
   "activationHooks": [

--- a/src/index.js
+++ b/src/index.js
@@ -189,14 +189,10 @@ export default {
           }
         }
 
-        let additionalFlag = '--stdin'
-
-        if (this.disableRubocopStdin === true) { additionalFlag = null }
-
         const command = this.command
           .split(/\s+/)
           .filter(i => i)
-          .concat(DEFAULT_ARGS, additionalFlag, filePath)
+          .concat(DEFAULT_ARGS, this.disableRubocopStdin ? null : '--stdin', filePath)
         const stdin = editor.getText()
         const cwd = getProjectDirectory(filePath)
         const exexOptions = {

--- a/src/index.js
+++ b/src/index.js
@@ -157,6 +157,9 @@ export default {
       atom.config.observe('linter-rubocop.disableWhenNoConfigFile', (value) => {
         this.disableWhenNoConfigFile = value
       }),
+      atom.config.observe('linter-rubocop.disableRubocopStdin', (value) => {
+        this.disableRubocopStdin = value
+      }),
     )
   },
 
@@ -186,10 +189,14 @@ export default {
           }
         }
 
+        let additionalFlag = '--stdin'
+
+        if (this.disableRubocopStdin === true) { additionalFlag = null }
+
         const command = this.command
           .split(/\s+/)
           .filter(i => i)
-          .concat(DEFAULT_ARGS, '--stdin', filePath)
+          .concat(DEFAULT_ARGS, additionalFlag, filePath)
         const stdin = editor.getText()
         const cwd = getProjectDirectory(filePath)
         const exexOptions = {

--- a/src/index.js
+++ b/src/index.js
@@ -178,7 +178,7 @@ export default {
         'source.ruby.chef',
       ],
       scope: 'file',
-      lintsOnChange: true,
+      lintsOnChange: this.disableRubocopStdin !== true,
       lint: async (editor) => {
         const filePath = editor.getPath()
 


### PR DESCRIPTION
When using linter-rubocop with a Docker image of Rubocop, it never find offences while remove the `--stdin` flag make it working perfectly.
This commit adds a new configuration option in order to not pass the stdin flag