### PR TITLE
Guard invalid path (#244)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -140,6 +140,8 @@ export default {
           }
 
           const filePath = textEditor.getPath()
+          if (!filePath) { return null }
+
           const command = this.command
             .split(/\s+/)
             .filter(i => i)
@@ -179,6 +181,7 @@ export default {
       lintsOnChange: true,
       lint: async (editor) => {
         const filePath = editor.getPath()
+        if (!filePath) { return null }
 
         if (this.disableWhenNoConfigFile === true) {
           const config = await helpers.findAsync(filePath, '.rubocop.yml')


### PR DESCRIPTION
Fix "Object.dirname is deprecated" error from Atom Deprecation Cop
   https://github.com/AtomLinter/linter-rubocop/issues/244 

ref https://github.com/AtomLinter/linter-flake8/pull/544
