### PR TITLE
Update .travis.yml to install fixed rubocop version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
       env: ATOM_CHANNEL=beta
 
 install:
-  - gem install --no-document rubocop
+  - gem install --no-document rubocop -v '~> 0.50'
 
 before_script:
   - rubocop --version


### PR DESCRIPTION
The shifting version causes the error strings to shift ever so slightly, breaking builds. Another option would be to make the error validation more permissive in the tests.