### PR TITLE
Update format for RuboCop 0.52.0

### DIFF
--- a/spec/linter-rubocop-spec.js
+++ b/spec/linter-rubocop-spec.js
@@ -67,8 +67,8 @@ describe('The RuboCop provider for Linter', () => {
     })
 
     it('verifies the first message', async () => {
-      const msgText = 'unterminated string meets end of file\n' +
-        '(Using Ruby 2.3 parser; configure using `TargetRubyVersion` parameter, under `AllCops`) (Lint/Syntax)'
+      const msgText = 'Lint/Syntax: unterminated string meets end of file\n' +
+        '(Using Ruby 2.3 parser; configure using `TargetRubyVersion` parameter, under `AllCops`)'
 
       const messages = await lint(editor)
 
@@ -88,8 +88,8 @@ describe('The RuboCop provider for Linter', () => {
     })
 
     it('verifies the first message', async () => {
-      const msgText = "Prefer single-quoted strings when you don't need " +
-        'string interpolation or special symbols. (Style/StringLiterals)'
+      const msgText = 'Style/StringLiterals: Prefer single-quoted strings ' +
+        "when you don't need string interpolation or special symbols."
 
       const messages = await lint(editor)
 

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,7 @@ const DEFAULT_ARGS = [
   '--force-exclusion',
   '--format', 'json',
   '--display-style-guide',
+  '--no-display-cop-names',
 ]
 const DOCUMENTATION_LIFETIME = 86400 * 1000 // 1 day TODO: Configurable?
 
@@ -110,7 +111,7 @@ const forwardRubocopToLinter =
 
     const linterMessage = {
       url,
-      excerpt: `${excerpt} (${copName})`,
+      excerpt: `${copName}: ${excerpt}`,
       severity: severityMapping[severity],
       description: url ? () => getMarkDown(url) : null,
       location: {


### PR DESCRIPTION
RuboCop 0.52.0 updated their format to display cop names by default in messages (https://github.com/bbatsov/rubocop/pull/5037). Since we were already showing the cop names this caused a few issues in the specs.

This disables the default forced cop names in the messages, but at the same time updates our style to match the default output of RuboCop.

Closes #254.