### PR TITLE
Only add --no-display-cop-names if needed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,21 @@ matrix:
   include:
     - os: linux
       rvm: 2.3.1
+      env: ATOM_CHANNEL=stable
+      install:
+        - gem install --no-document rubocop -v '< 0.52.0'
+
+    - os: linux
+      rvm: 2.3.1
+      env: ATOM_CHANNEL=stable
+      install:
+        - gem install --no-document rubocop
 
     - os: linux
       rvm: 2.3.1
       env: ATOM_CHANNEL=beta
-
-install:
-  - gem install --no-document rubocop
+      install:
+        - gem install --no-document rubocop
 
 before_script:
   - rubocop --version

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "atom-package-deps": "^4.5.0",
     "pluralize": "^7.0.0",
     "request": "^2.81.0",
-    "request-promise": "^4.1.1"
+    "request-promise": "^4.1.1",
+    "semver": "^5.5.0"
   },
   "devDependencies": {
     "eslint": "^4.6.0",

--- a/src/index.js
+++ b/src/index.js
@@ -6,17 +6,18 @@ import path from 'path'
 import pluralize from 'pluralize'
 import * as helpers from 'atom-linter'
 import { get } from 'request-promise'
+import semver from 'semver'
 
 const DEFAULT_ARGS = [
   '--cache', 'false',
   '--force-exclusion',
   '--format', 'json',
   '--display-style-guide',
-  '--no-display-cop-names',
 ]
 const DOCUMENTATION_LIFETIME = 86400 * 1000 // 1 day TODO: Configurable?
 
 const docsRuleCache = new Map()
+const execPathVersions = new Map()
 let docsLastRetrieved
 
 const takeWhile = (source, predicate) => {
@@ -45,7 +46,6 @@ const parseFromStd = (stdout, stderr) => {
 
 const getProjectDirectory = filePath =>
   atom.project.relativizePath(filePath)[0] || path.dirname(filePath)
-
 
 // Retrieves style guide documentation with cached responses
 const getMarkDown = async (url) => {
@@ -122,6 +122,31 @@ const forwardRubocopToLinter =
     return linterMessage
   }
 
+const determineExecVersion = async (execPath) => {
+  const versionString = await helpers.exec(execPath, ['--version'], { ignoreExitCode: true })
+  const versionPattern = /^(\d+\.\d+\.\d+)/i
+  const match = versionString.match(versionPattern)
+  if (match !== null && match[1]) {
+    execPathVersions.set(execPath, match[1])
+  }
+}
+
+const getRubocopVersion = async (execPath) => {
+  if (!execPathVersions.has(execPath)) {
+    await determineExecVersion(execPath)
+  }
+  return execPathVersions.get(execPath)
+}
+
+const getCopNameArg = async (execPath) => {
+  const version = await getRubocopVersion(execPath)
+  if (semver.gte(version, '0.52.0')) {
+    return ['--no-display-cop-names']
+  }
+
+  return []
+}
+
 export default {
   activate() {
     require('atom-package-deps').install('linter-rubocop', true)
@@ -145,7 +170,10 @@ export default {
           const command = this.command
             .split(/\s+/)
             .filter(i => i)
-            .concat(DEFAULT_ARGS, '--auto-correct', filePath)
+            .concat(DEFAULT_ARGS, '--auto-correct')
+          command.push(...(await getCopNameArg(command[0])))
+          command.push(filePath)
+
           const cwd = getProjectDirectory(filePath)
           const { stdout, stderr } = await helpers.exec(command[0], command.slice(1), { cwd, stream: 'both' })
           const { summary: { offense_count: offenseCount } } = parseFromStd(stdout, stderr)
@@ -193,7 +221,9 @@ export default {
         const command = this.command
           .split(/\s+/)
           .filter(i => i)
-          .concat(DEFAULT_ARGS, '--stdin', filePath)
+          .concat(DEFAULT_ARGS)
+        command.push(...(await getCopNameArg(command[0])))
+        command.push('--stdin', filePath)
         const stdin = editor.getText()
         const cwd = getProjectDirectory(filePath)
         const exexOptions = {


### PR DESCRIPTION
Check the version of RuboCop and only add the `--no-display-cop-names` flag if it is v0.52.0 or higher.

Fixes #257