### PR TITLE
 Fix #259 and related issues running with rbenv/bundler

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ If you would like to contribute enhancements or fixes, please do the following:
 Please note that modifications should follow these coding guidelines:
 
 -   Indent is 2 spaces.
--   Code should pass the `coffeelint` linter.
+-   Code should pass `npm run lint` (eslint).
 -   Vertical whitespace helps readability, don’t be afraid to use it.
 
 Thank you for helping out!


### PR DESCRIPTION
This fixes several related issues running with a command like `rbenv exec bundle exec rubocop`:
* #259
* `determineExecVersion` assumes that the first argument in this.command
  will be a rubocop executable. I changed it to run the entire
  command with `--version` on the end.
* Under rbenv/bundler, the rubocop version can vary by working directory.
  I changed the `execPathVersions` cache key to include cwd.

I tested:
* Lints with the default command
* Lints with `rbenv exec bundle exec rubocop`
* Autocorrected a file
* Throws a more helpful error when determineExecVersion can't parse the output
* Ran `npm run lint`
* Ran `npm run test`. The autocorrect test timed out locally but since I couldn't get the tests passing on master either I'm going to rely on CircleCI and fix this PR if it fails there.

Fixes #259.