### PR TITLE
Correct offenses on save

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [v2.2.2](https://github.com/AtomLinter/linter-rubocop/compare/v2.2.1...v2.2.2)
+
+###### Bug Fixes:
+* Fix for RuboCop versions below v0.52.0 (#258)
+
 ## [v2.2.1](https://github.com/AtomLinter/linter-rubocop/compare/v2.2.0...v2.2.1)
 
 ###### Changes:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "linter-rubocop",
   "main": "./src/index.js",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Lint Ruby on the fly, using rubocop",
   "repository": "https://github.com/AtomLinter/linter-rubocop",
   "license": "MIT",


### PR DESCRIPTION
Inspired by eslint, this adds the option to lint on save.  I was bored one night and added this.  It also gets a much more accurate offense correction count.  Not sure if the "fix on save" feature is a desired feature due to the resource demand of Rubocop which is why I left the config to be `false`.  