### PR TITLE
add new language-chef source types

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -208,6 +208,8 @@ export default {
         'source.ruby.rails',
         'source.ruby.rspec',
         'source.ruby.chef',
+        'source.chef.metadata',
+        'source.chef.recipes',
       ],
       scope: 'file',
       lintsOnChange: true,


### PR DESCRIPTION
The latest release of language-chef changes the source types from a ruby child to its own `source.chef.*`. https://github.com/sous-chefs/language-chef/pull/13

Fixes #273 

Signed-off-by: Matt Kulka <mkulka@parchment.com>