### PR TITLE
Use activationhook scope

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,9 +23,9 @@
     }
   },
   "activationHooks": [
-    "language-ruby:grammar-used",
-    "language-ruby-on-rails:grammar-used",
-    "language-chef:grammar-used"
+    "source.ruby:root-scope-used",
+    "source.ruby.rails:root-scope-used",
+    "source.chef.recipes:root-scope-used"
   ],
   "scripts": {
     "lint": "eslint .",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,8 @@
       "atom": true
     },
     "env": {
-      "node": true
+      "node": true,
+      "browser": true
     }
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -2,11 +2,7 @@
 
 // eslint-disable-next-line import/extensions, import/no-extraneous-dependencies
 import { CompositeDisposable } from 'atom'
-import path from 'path'
-import pluralize from 'pluralize'
-import * as helpers from 'atom-linter'
 import { get } from 'request-promise'
-import semver from 'semver'
 
 const DEFAULT_ARGS = [
   '--cache', 'false',
@@ -19,6 +15,26 @@ const DOCUMENTATION_LIFETIME = 86400 * 1000 // 1 day TODO: Configurable?
 const docsRuleCache = new Map()
 const execPathVersions = new Map()
 let docsLastRetrieved
+
+let helpers
+let path
+let pluralize
+let semver
+
+const loadDeps = () => {
+  if (!helpers) {
+    helpers = require('atom-linter')
+  }
+  if (!path) {
+    path = require('path')
+  }
+  if (!pluralize) {
+    pluralize = require('pluralize')
+  }
+  if (!semver) {
+    semver = require('semver')
+  }
+}
 
 const takeWhile = (source, predicate) => {
   const result = []
@@ -153,6 +169,8 @@ export default {
   activate() {
     require('atom-package-deps').install('linter-rubocop', true)
 
+    loadDeps()
+
     this.subscriptions = new CompositeDisposable()
 
     // Register fix command
@@ -212,6 +230,8 @@ export default {
       lint: async (editor) => {
         const filePath = editor.getPath()
         if (!filePath) { return null }
+
+        loadDeps()
 
         if (this.disableWhenNoConfigFile === true) {
           const config = await helpers.findAsync(filePath, '.rubocop.yml')

--- a/src/index.js
+++ b/src/index.js
@@ -167,9 +167,17 @@ const getCopNameArg = async (command, cwd) => {
 
 export default {
   activate() {
-    require('atom-package-deps').install('linter-rubocop', true)
-
-    loadDeps()
+    this.idleCallbacks = new Set()
+    let depsCallbackID
+    const installLinterRubocopDeps = () => {
+      this.idleCallbacks.delete(depsCallbackID)
+      if (!atom.inSpecMode()) {
+        require('atom-package-deps').install('linter-rubocop', true)
+      }
+      loadDeps()
+    }
+    depsCallbackID = window.requestIdleCallback(installLinterRubocopDeps)
+    this.idleCallbacks.add(depsCallbackID)
 
     this.subscriptions = new CompositeDisposable()
 
@@ -212,6 +220,8 @@ export default {
   },
 
   deactivate() {
+    this.idleCallbacks.forEach(callbackID => window.cancelIdleCallback(callbackID))
+    this.idleCallbacks.clear()
     this.subscriptions.dispose()
   },
 


### PR DESCRIPTION
- Use the `scope.name:root-scope-used` hook, specifically to avoid the need to list out the name of all the different grammar packages that provide that scope.
- Package dependencies lazy loading on Atom startup.
