### PR TITLE
Parallel execution option

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,12 @@
       "title": "Disable when no .rubocop.yml config file is found",
       "default": false,
       "description": "Only run linter if a RuboCop config file is found somewhere in the path for the current file."
-    }
+    },
+    "useParallelExecution": {
+      "type": "boolean",
+      "default": false,
+      "description": "Use available CPUs to execute inspection in parallel."
+    }    
   },
   "activationHooks": [
     "source.ruby:root-scope-used",

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,6 @@ import { CompositeDisposable } from 'atom'
 import { get } from 'request-promise'
 
 const DEFAULT_ARGS = [
-  '--cache', 'false',
   '--force-exclusion',
   '--format', 'json',
   '--display-style-guide',
@@ -216,6 +215,9 @@ export default {
       atom.config.observe('linter-rubocop.disableWhenNoConfigFile', (value) => {
         this.disableWhenNoConfigFile = value
       }),
+      atom.config.observe('linter-rubocop.useParallelExecution', (value) => {
+        this.useParallelExecution = value
+      }),
     )
   },
 
@@ -256,6 +258,9 @@ export default {
           .filter(i => i)
           .concat(DEFAULT_ARGS)
         command.push(...(await getCopNameArg(command, cwd)))
+        if (this.useParallelExecution) {
+          command.push('--parallel')
+        }
         command.push('--stdin', filePath)
         const stdin = editor.getText()
         const exexOptions = {


### PR DESCRIPTION
Use available CPUs to execute inspection in parallel, we remove the `--cache` flag because is not compatible with the parallel execution.