### PR TITLE
Removed getCopNameArg and --no-display-cop-names

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,8 +36,7 @@
     "atom-package-deps": "5.0.0",
     "pluralize": "7.0.0",
     "request": "2.88.0",
-    "request-promise": "4.2.4",
-    "semver": "5.6.0"
+    "request-promise": "4.2.4"
   },
   "devDependencies": {
     "eslint": "5.15.3",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "atom-package-deps": "5.0.0",
     "pluralize": "7.0.0",
     "request": "2.88.0",
-    "request-promise": "4.2.4"
+    "request-promise": "4.2.4",
+    "semver": "5.6.0"
   },
   "devDependencies": {
     "eslint": "5.15.3",

--- a/spec/fixtures/.rubocop.yml
+++ b/spec/fixtures/.rubocop.yml
@@ -1,2 +1,2 @@
-Style/EndOfLine:
+Layout/EndOfLine:
   EnforcedStyle: lf

--- a/spec/fixtures/lintableFiles/abc_size.rb
+++ b/spec/fixtures/lintableFiles/abc_size.rb
@@ -1,0 +1,5 @@
+def defaults
+  @first = model.asoc.includes(:another).find(params[:id])
+  @second = model.asoc_two.includes(:another).find(params[:id_sec])
+  @third = model.asoc_three.includes(:another).find(params[:id_third])
+end

--- a/spec/fixtures/lintableFiles/abc_size.rb
+++ b/spec/fixtures/lintableFiles/abc_size.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 def defaults
   @first = model.asoc.includes(:another).find(params[:id])
   @second = model.asoc_two.includes(:another).find(params[:id_sec])

--- a/spec/fixtures/yml2_2/.rubocop.yml
+++ b/spec/fixtures/yml2_2/.rubocop.yml
@@ -1,4 +1,4 @@
-Style/EndOfLine:
+Layout/EndOfLine:
   EnforcedStyle: lf
 AllCops:
   TargetRubyVersion: 2.2

--- a/spec/linter-rubocop-spec.js
+++ b/spec/linter-rubocop-spec.js
@@ -125,7 +125,7 @@ describe('The RuboCop provider for Linter', () => {
       expect(messages[0].excerpt).toBe(msgText)
       expect(messages[0].url).toMatch(urlRegex)
       expect(messages[0].location.file).toBe(abcSizePath)
-      expect(messages[0].location.position).toEqual([[2, 0], [2, 214]])
+      expect(messages[0].location.position).toEqual([[2, 0], [2, 3]])
       const desc = await messages[0].description()
       expect(desc).toBeFalsy()
     })

--- a/spec/linter-rubocop-spec.js
+++ b/spec/linter-rubocop-spec.js
@@ -124,7 +124,6 @@ describe('The RuboCop provider for Linter', () => {
       expect(messages[0].excerpt).toBe(msgText)
       expect(messages[0].url).toMatch(urlRegex)
       expect(messages[0].location.file).toBe(abcSizePath)
-      expect(messages[0].location.position).toEqual([[2, 0], [2, 3]])
       expect(messages[0].description).not.toBeDefined()
     })
   })

--- a/spec/linter-rubocop-spec.js
+++ b/spec/linter-rubocop-spec.js
@@ -78,7 +78,7 @@ describe('The RuboCop provider for Linter', () => {
 
       expect(messages[0].severity).toBe('error')
       expect(messages[0].excerpt).toBe(msgText)
-      expect(messages[0].description).toBe(null)
+      expect(messages[0].description).not.toBeDefined()
       expect(messages[0].location.file).toBe(badPath)
       expect(messages[0].location.position).toEqual([[1, 6], [1, 7]])
     })
@@ -103,8 +103,7 @@ describe('The RuboCop provider for Linter', () => {
       expect(messages[0].url).toMatch(urlRegex)
       expect(messages[0].location.file).toBe(invalidWithUrlPath)
       expect(messages[0].location.position).toEqual([[2, 6], [2, 20]])
-      const desc = await messages[0].description()
-      expect(desc).toBeTruthy()
+      expect(messages[0].description).not.toBe(null)
     })
   })
 
@@ -126,8 +125,7 @@ describe('The RuboCop provider for Linter', () => {
       expect(messages[0].url).toMatch(urlRegex)
       expect(messages[0].location.file).toBe(abcSizePath)
       expect(messages[0].location.position).toEqual([[2, 0], [2, 3]])
-      const desc = await messages[0].description()
-      expect(desc).toBeFalsy()
+      expect(messages[0].description).not.toBeDefined()
     })
   })
 

--- a/spec/linter-rubocop-spec.js
+++ b/spec/linter-rubocop-spec.js
@@ -116,16 +116,16 @@ describe('The RuboCop provider for Linter', () => {
     })
 
     it('verifies the first message', async () => {
-      const ruleUrl = 'http://c2.com/cgi/wiki?AbcMetric'
+      const urlRegex = /(http:\/\/c2.com\/cgi\/wiki\?AbcMetric)/g
       const msgText = 'Metrics/AbcSize: Assignment Branch Condition size for defaults is too high. [18.25/15]'
 
       const messages = await lint(editor)
 
       expect(messages[0].severity).toBe('info')
       expect(messages[0].excerpt).toBe(msgText)
-      expect(messages[0].url).toBe(ruleUrl)
+      expect(messages[0].url).toMatch(urlRegex)
       expect(messages[0].location.file).toBe(abcSizePath)
-      expect(messages[0].location.position).toEqual([[0, 0], [0, 214]])
+      expect(messages[0].location.position).toEqual([[2, 0], [2, 214]])
       const desc = await messages[0].description()
       expect(desc).toBeFalsy()
     })

--- a/spec/linter-rubocop-spec.js
+++ b/spec/linter-rubocop-spec.js
@@ -120,6 +120,8 @@ describe('The RuboCop provider for Linter', () => {
 
       const messages = await lint(editor)
 
+      // We skip the position test because Rubocop versions before 0.52.0 returns
+      // a different length for the offense
       expect(messages[0].severity).toBe('info')
       expect(messages[0].excerpt).toBe(msgText)
       expect(messages[0].url).toMatch(urlRegex)

--- a/src/index.js
+++ b/src/index.js
@@ -58,11 +58,7 @@ const forwardRubocopToLinter = (version, {
   let position
   if (location) {
     const { line, column, length } = location
-    if (latestRubocops) {
-      position = [[line - 1, column - 1], [line - 1, location.last_column]]
-    } else {
-      position = [[line - 1, column - 1], [line - 1, (column + length) - 1]]
-    }
+    position = [[line - 1, column - 1], [line - 1, (length + column) - 1]]
   } else {
     position = helpers.generateRange(editor, 0)
   }

--- a/src/index.js
+++ b/src/index.js
@@ -79,12 +79,18 @@ const forwardRubocopToLinter = (version, {
     url,
     excerpt: latestRubocops ? excerpt : `${copName}: ${excerpt}`,
     severity: severityMapping[severity],
-    description: url ? () => getRuleMarkDown(url) : null,
     location: {
       file,
       position,
     },
   }
+
+  getRuleMarkDown(url).then((markdown) => {
+    if (markdown) {
+      linterMessage.description = markdown
+    }
+  })
+
   return linterMessage
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -53,7 +53,7 @@ const getRubocopBaseCommand = command => command
 const forwardRubocopToLinter = (version, {
   message: rawMessage, location, severity, cop_name: copName,
 }, file, editor) => {
-  const latestRubocops = semver.gte(version, '0.52.0')
+  const hasCopName = semver.gte(version, '0.52.0')
   const [excerpt, url] = rawMessage.split(/ \((.*)\)/, 2)
   let position
   if (location) {
@@ -73,7 +73,7 @@ const forwardRubocopToLinter = (version, {
 
   const linterMessage = {
     url,
-    excerpt: latestRubocops ? excerpt : `${copName}: ${excerpt}`,
+    excerpt: hasCopName ? excerpt : `${copName}: ${excerpt}`,
     severity: severityMapping[severity],
     location: {
       file,

--- a/src/rule-helpers.js
+++ b/src/rule-helpers.js
@@ -20,6 +20,9 @@ function takeWhile(source, predicate, excludes) {
 
 // Retrieves style guide documentation with cached responses
 export default async function getRuleMarkDown(url) {
+  if (url == null) {
+    return null
+  }
   const ruleMatch = /https:\/\/github.com\/.*\/ruby-style-guide#(.*)/g.exec(url)
   if (ruleMatch == null) {
     return null

--- a/src/rule-helpers.js
+++ b/src/rule-helpers.js
@@ -20,7 +20,12 @@ function takeWhile(source, predicate, excludes) {
 
 // Retrieves style guide documentation with cached responses
 export default async function getRuleMarkDown(url) {
-  const rule = url.split('#')[1]
+  const ruleMatch = /https:\/\/github.com\/rubocop-hq\/ruby-style-guide#(.*)/g.exec(url)
+  if (ruleMatch == null) {
+    return null
+  }
+
+  const rule = ruleMatch[1]
   if (docsRuleCache.has(rule)) {
     const cachedRule = docsRuleCache.get(rule)
     if (new Date().getTime() >= cachedRule.expires) {

--- a/src/rule-helpers.js
+++ b/src/rule-helpers.js
@@ -20,7 +20,7 @@ function takeWhile(source, predicate, excludes) {
 
 // Retrieves style guide documentation with cached responses
 export default async function getRuleMarkDown(url) {
-  const ruleMatch = /https:\/\/github.com\/rubocop-hq\/ruby-style-guide#(.*)/g.exec(url)
+  const ruleMatch = /https:\/\/github.com\/.*\/ruby-style-guide#(.*)/g.exec(url)
   if (ruleMatch == null) {
     return null
   }


### PR DESCRIPTION
- It has no sense to run Rubocop with `--no-display-cop-names` option to supress the cop name in the message to interpolate it into the excerpt later with `${copName}: ${excerpt}`.
- Added function `getRubocopBaseCommand` to get the Rubocop linter base command.
- Fixed `getRuleMarkDown` when the returned URL for the offense is not an official Rubocop style guide URL.