### PR TITLE
Allow Rubocop offense caching

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,6 @@ import { CompositeDisposable } from 'atom'
 import getRuleMarkDown from './rule-helpers'
 
 const DEFAULT_ARGS = [
-  '--cache', 'false',
   '--force-exclusion',
   '--format', 'json',
   '--display-style-guide',


### PR DESCRIPTION
Fixes #249,  Rubocop use offense caching by default implemented in https://github.com/rubocop-hq/rubocop/commit/62d92f, there is no initial reason to disable it and will be good to the linter's general performance.