### PR TITLE
Make Renovate ignore fixture configs

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,6 +78,9 @@
         ],
         "groupName": "ESLint packages"
       }
+    ],
+    "ignorePaths": [
+      "spec/fixtures/*"
     ]
   },
   "eslintConfig": {


### PR DESCRIPTION
Tell Renovate to ignore the version of Ruby in the spec fixtures.