### PR TITLE
Make Renovate ignore fixture configs, take two

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
       }
     ],
     "ignorePaths": [
-      "spec/fixtures/*"
+      "spec/fixtures/**"
     ]
   },
   "eslintConfig": {


### PR DESCRIPTION
This will hopefully fix things, verified against the configuration from [another repository](https://github.com/AtomLinter/linter-hadolint/blob/ad51cccb386505af9f5722a0114224b36e258a3e/package.json#L69-L71) that had a similar issue.

Unfortunately the only way to be sure is to merge this and see what Renovate does.