### PR TITLE
Updated minimum Atom version to 1.30

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "repository": "https://github.com/AtomLinter/linter-rubocop",
   "license": "MIT",
   "engines": {
-    "atom": ">=1.4.0 <2.0.0"
+    "atom": ">=1.30.0 <2.0.0"
   },
   "configSchema": {
     "command": {


### PR DESCRIPTION
Fixes #314, activation hooks support by grammar scope was implemented on Atom v1.30