### PR TITLE
Removed configuration to run Rubocop with extra Rails cops

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,11 +20,6 @@
       "title": "Disable when no .rubocop.yml config file is found",
       "default": false,
       "description": "Only run linter if a RuboCop config file is found somewhere in the path for the current file."
-    },
-    "runExtraRailsCops": {
-      "type": "boolean",
-      "default": false,
-      "description": "Run extra Rails cops."
     }
   },
   "activationHooks": [

--- a/src/index.js
+++ b/src/index.js
@@ -174,7 +174,7 @@ export default {
       }),
       atom.config.observe('linter-rubocop.disableWhenNoConfigFile', (value) => {
         this.disableWhenNoConfigFile = value
-      })
+      }),
     )
   },
 

--- a/src/index.js
+++ b/src/index.js
@@ -174,10 +174,7 @@ export default {
       }),
       atom.config.observe('linter-rubocop.disableWhenNoConfigFile', (value) => {
         this.disableWhenNoConfigFile = value
-      }),
-      atom.config.observe('linter-rubocop.runExtraRailsCops', (value) => {
-        this.runExtraRailsCops = value
-      }),
+      })
     )
   },
 


### PR DESCRIPTION
According to https://github.com/rubocop-hq/rubocop/issues/5976 Rails department was removed from Rubocop core and extracted to a plugin, anyway this option had no effect because was removed accidentaly on e9c0319