### PR TITLE
refactor: added error handler, removed buildExecOptions

### DIFF
--- a/src/rubocop/Runner.js
+++ b/src/rubocop/Runner.js
@@ -17,19 +17,15 @@ function currentDirectory(filePath) {
   return atom.project.relativizePath(filePath)[0] || path.dirname(filePath)
 }
 
-function buildExecOptions(filePath, extraOptions = {}) {
-  const baseOptions = {
-    cwd: currentDirectory(filePath),
-    stream: 'both',
-    timeout: 10000,
-    uniqueKey: `linter-rubocop::${filePath}`,
-    ignoreExitCode: true,
-  }
-  return Object.assign(baseOptions, extraOptions)
-}
-
 function isWindows() {
   return (process.platform === 'win32' || process.platform === 'win64')
+}
+
+function errorHandler(e) {
+  if (e.message !== TIMEOUT_ERROR_MSG) {
+    throw e
+  }
+  atom.notifications.addInfo(LINTER_TIMEOUT_MSG, { description: LINTER_TIMEOUT_DESC })
 }
 
 export default class Runner {
@@ -55,10 +51,7 @@ export default class Runner {
     )
 
     if (output.error) {
-      if (output.error.message !== TIMEOUT_ERROR_MSG) {
-        throw output.error
-      }
-      atom.notifications.addInfo(LINTER_TIMEOUT_MSG, { description: LINTER_TIMEOUT_DESC })
+      errorHandler(output.error)
       return null
     }
 
@@ -79,15 +72,20 @@ export default class Runner {
       output = await exec(
         command[0],
         command.slice(1),
-        buildExecOptions(filePath, options),
+        {
+          cwd: currentDirectory(filePath),
+          stream: 'both',
+          timeout: 10000,
+          uniqueKey: `linter-rubocop::${filePath}`,
+          ignoreExitCode: true,
+          ...options,
+        },
       )
     } catch (e) {
-      if (e.message !== TIMEOUT_ERROR_MSG) {
-        throw e
-      }
-      atom.notifications.addInfo(LINTER_TIMEOUT_MSG, { description: LINTER_TIMEOUT_DESC })
+      errorHandler(e)
       return null
     }
+
     return output
   }
 }

--- a/src/rubocop/Runner.js
+++ b/src/rubocop/Runner.js
@@ -17,10 +17,6 @@ function currentDirectory(filePath) {
   return atom.project.relativizePath(filePath)[0] || path.dirname(filePath)
 }
 
-function isWindows() {
-  return (process.platform === 'win32' || process.platform === 'win64')
-}
-
 function errorHandler(e) {
   if (e.message !== TIMEOUT_ERROR_MSG) {
     throw e
@@ -47,7 +43,13 @@ export default class Runner {
     const output = childProcess.spawnSync(
       command[0],
       command.slice(1),
-      { cwd, shell: isWindows(), ...options },
+      {
+        cwd,
+        shell:
+          process.platform === 'win32'
+          || process.platform === 'win64',
+        ...options,
+      },
     )
 
     if (output.error) {


### PR DESCRIPTION
Added error handler to remove duplicated code.
Removed `buildExecOptions` and `isWindows` methods.