### PR TITLE
ci: eslintrc prepared for Eslint v7

### DIFF
--- a/spec/.eslintrc.js
+++ b/spec/.eslintrc.js
@@ -4,11 +4,11 @@ module.exports = {
     jasmine: true,
   },
   rules: {
-    "import/no-extraneous-dependencies": [
-      "error",
+    'import/no-extraneous-dependencies': [
+      'error',
       {
-        "devDependencies": true
-      }
-    ]
-  }
-};
+        devDependencies: true,
+      },
+    ],
+  },
+}


### PR DESCRIPTION
/home/travis/build/AtomLinter/linter-rubocop/spec/.eslintrc.js
- 7:5   error  Strings must use singlequote
- 8:7   error  Strings must use singlequote
- 10:9   error  Unnecessarily quoted property 'devDependencies' found
- 10:9   error  Strings must use singlequote
- 10:32  error  Missing trailing comma
- 11:8   error  Missing trailing comma
- 12:6   error  Missing trailing comma
- 13:4   error  Missing trailing comma
- 14:2   error  Extra semicolon