### PR TITLE
fix: incorrect extractnig of the url from the error message

### DIFF
--- a/src/rubocop/OffenseFormatter.js
+++ b/src/rubocop/OffenseFormatter.js
@@ -34,7 +34,7 @@ export default class OffenseFormatter extends ErrorFormatter {
     message: rawMessage, location, severity, cop_name: copName,
   }, filePath) {
     const hasCopName = satisfies(version, HASCOPNAME_VERSION_RANGE)
-    const [excerpt, url] = rawMessage.split(/ \((.*)\)/, 2)
+    const [excerpt, url] = rawMessage.split(/(?=(?=\((http.*)(, ))|(\(http.*\)))/, 2)
     let position
     if (location) {
       const { line, column, length } = location


### PR DESCRIPTION
When part of the error message is inside the parentheses it will be taken as the url. In such case the message will be cut and the rest will be taken as the url.
<img width="399" alt="incorrect_message" src="https://user-images.githubusercontent.com/23483877/117195149-9d216d00-aded-11eb-999f-1bf0391f483b.png">
<img width="1053" alt="incorrect_pane" src="https://user-images.githubusercontent.com/23483877/117195152-9d216d00-aded-11eb-96be-0679484f1616.png">
After the fix:
<img width="893" alt="correct_message" src="https://user-images.githubusercontent.com/23483877/117195139-9a267c80-aded-11eb-9278-a5cf5c2d9d35.png">
<img width="1051" alt="correct_pane" src="https://user-images.githubusercontent.com/23483877/117195145-9bf04000-aded-11eb-8947-9971958e93a6.png">

The condition in the regex is for the case when there are two urls in the message. In this case only the first one will be used.